### PR TITLE
Improve readability, fonts more like metacpan

### DIFF
--- a/templates/perldoc.html.ep
+++ b/templates/perldoc.html.ep
@@ -15,7 +15,7 @@
     <style>
       body {
         background: #f4f4f5;
-        color: #445555;
+        color: #333333;
       }
       .navbar-dark {
         background-image: -webkit-linear-gradient(top, #005f85 0, #002e49 100%);
@@ -29,7 +29,7 @@
       .navbar-dark .navbar-nav .nav-link:hover { color: #ffef68 }
       #wrapperlicious {
         margin: 0 auto;
-        font: 0.9em 'Helvetica Neue', Helvetica, sans-serif;
+        font: 1em 'Helvetica Neue', Helvetica, sans-serif;
         font-weight: normal;
         line-height: 1.5em;
         margin: 0;
@@ -55,7 +55,7 @@
         color: inherit;
         background-color: rgba(0, 0, 0, 0.04);
         border-radius: 3px;
-        font: 0.9em Consolas, Menlo, Monaco, Courier, monospace;
+        font: 0.9em Consolas, Menlo, Monaco, monospace;
         padding: 0.3em;
       }
       #wrapperlicious dd {
@@ -78,14 +78,14 @@
       #wrapperlicious pre {
         border: 1px solid #c1c1c1;
         border-radius: 3px;
-        font: 100% Consolas, Menlo, Monaco, Courier, monospace;
+        font: 100% Consolas, Menlo, Monaco, monospace;
         margin-bottom: 1em;
         margin-top: 1em;
       }
       #wrapperlicious pre > code {
         display: block;
         background-color: #f6f6f6;
-        font: 0.9em Consolas, Menlo, Monaco, Courier, monospace;
+        font: 0.9em Consolas, Menlo, Monaco, monospace;
         line-height: 1.5em;
         text-align: left;
         white-space: pre;


### PR DESCRIPTION
Hi. What do you think about these small changes in the CSS?

They render fonts more like metacpan:

- `font-color: #333`: a bit blacker
- `font-size: 1em`: a bit larger. And we'd have less chars per line. Currently for me it renders ~135 chars per line. Compare with https://metacpan.org/pod/Catalyst (~115 chars per line). https://docs.python.org/3/tutorial/introduction.html (~105 chars per line)
- remove 'Courier' from the pre/code fonts: at least in Firefox (Debian), it renders very thin