### PR TITLE
remove unnecessary string "init" in template

### DIFF
--- a/templates/perldoc.html.ep
+++ b/templates/perldoc.html.ep
@@ -232,4 +232,3 @@
     <script>hljs.highlightAll();</script>
   </body>
 </html>
-init


### PR DESCRIPTION
which was added in d4986e2c1b879178b00d7c61f22aac3b333ce322 and it appears in html

![perldoc perl org_functions_try](https://user-images.githubusercontent.com/12870472/215652462-680064d7-95a2-4887-86d3-f01625769b56.png)

