### PR TITLE
Search field is now aware of the search query value in the url. Also fixed closing ul tag.

### DIFF
--- a/templates/menubar.html.ep
+++ b/templates/menubar.html.ep
@@ -110,7 +110,7 @@
         }
       </script>
       <button id="content-expand-button" type="button" class="btn btn-outline-light d-none d-lg-inline-block mr-2" onclick="toggle_expand()">Expand</button>
-    <ul>
+    </ul>
 % if (defined app->search_backend) {
 %   my $search_params = config('search_params') // {};
     <form class="form-inline" method="get" action="<%= url_for("$current_prefix/search") %>">

--- a/templates/menubar.html.ep
+++ b/templates/menubar.html.ep
@@ -117,7 +117,7 @@
 %   foreach my $name (keys %$search_params) {
       <input type="hidden" name="<%= $name %>" value="<%= $search_params->{$name} %>">
 %   }
-      <input class="form-control mr-3" type="search" name="q" placeholder="Search" aria-label="Search">
+      <input class="form-control mr-3" type="search" name="q" placeholder="Search" aria-label="Search" value="<%= $c->param('q') %>">
     </form>
 % }
   </div>


### PR DESCRIPTION
1. Modified [templates/menubar.html.ep](templates/menubar.html.ep) so that the search field will take on the value of the `?q=` parameter in the url.
   - Original request by @ilmari in `#perl` on `irc.perl.org` on 2024-06-13.

2. Changed `<ul>` to `</ul>` as it is meant to be a closing tag.
   - Credit: @mauke in `#perl` on `irc.perl.org` on 2024-06-13.